### PR TITLE
Add a streaming control interface

### DIFF
--- a/schunk_svh_driver/cfg/schunk_svh_driver.yaml
+++ b/schunk_svh_driver/cfg/schunk_svh_driver.yaml
@@ -11,6 +11,8 @@ controller_manager:
     right_hand:
       type: joint_trajectory_controller/JointTrajectoryController
 
+    streaming_controller:
+      type: position_controllers/JointGroupPositionController
 
 left_hand:
   ros__parameters:
@@ -49,3 +51,16 @@ right_hand:
     state_interfaces:
       - position
       - velocity
+
+streaming_controller:
+  ros__parameters:
+    joints:
+      - Right_Hand_Thumb_Flexion
+      - Right_Hand_Thumb_Opposition
+      - Right_Hand_Index_Finger_Distal
+      - Right_Hand_Index_Finger_Proximal
+      - Right_Hand_Middle_Finger_Distal
+      - Right_Hand_Middle_Finger_Proximal
+      - Right_Hand_Ring_Finger
+      - Right_Hand_Pinky
+      - Right_Hand_Finger_Spread

--- a/schunk_svh_simulation/launch/simulation.launch.py
+++ b/schunk_svh_simulation/launch/simulation.launch.py
@@ -113,6 +113,7 @@ def generate_launch_description():
     # Inactive controllers
     inactive_list = [
         "left_hand",
+        "streaming_controller",
     ]
     inactive_spawners = [
         controller_spawner(controller, "--inactive") for controller in inactive_list


### PR DESCRIPTION
## Background
Teleoperation and machine learning need a faster and more direct control interface to the SVH.
Let's explore what we get with a `position_controllers/JointGroupPositionController` out of the box.

## Steps
- [x] Add a `position_controllers/JointGroupPositionController`
- [ ] Test how to best send data to this interface
- [ ] Update example scripts
- [ ] Update readmes